### PR TITLE
:arrow_up: Upgrade `action/` actions

### DIFF
--- a/.github/workflows/demo_builder.yml
+++ b/.github/workflows/demo_builder.yml
@@ -52,14 +52,14 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version != '' }}
         with:
           submodules: true
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.version }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version == '' }}
         with:
           submodules: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,14 +49,14 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version != '' }}
         with:
           submodules: true
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.version }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version == '' }}
         with:
           submodules: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,14 +34,14 @@ jobs:
   docs:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version != '' }}
         with:
           submodules: true
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.version }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version == '' }}
         with:
           submodules: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,14 +34,14 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version != '' }}
         with:
           submodules: true
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.version }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version == '' }}
         with:
           submodules: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with:
           submodules: true
           repository: ${{ inputs.repo }}
@@ -40,8 +40,7 @@ jobs:
       - name: 📥 Install Conan
         run: pip install conan
 
-      - run: mkdir docs
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v4.1.3
         with:
           path: docs
 
@@ -49,13 +48,13 @@ jobs:
         run: wget "https://img.shields.io/badge/Latest%20Version-$(conan inspect . | grep version | cut -c 10- | sed s/-/~/ )-green" -O docs/latest_version.svg
 
       - name: Setup Pages
-        uses: actions/configure-pages@v2
+        uses: actions/configure-pages@v4.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: "docs"
 
       - name: 🚀 Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4.0.4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,14 +69,14 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version != '' }}
         with:
           submodules: true
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.version }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version == '' }}
         with:
           submodules: true
@@ -145,7 +145,7 @@ jobs:
           grep -Eo 'https://img.shields.io/badge/[^)]*')
           -O build/coverage/coverage.svg
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.3.1
         if: github.ref == 'refs/heads/main' && github.repository == inputs.repo
         with:
           name: coverage


### PR DESCRIPTION
- 🐛 Fix the bug with publish that causes the uploaded artifacts to not be downloaded.
- 🐛 Remove "pull" ci for tests. This was supposed to be a breaking change in the migration to 5.x.y update, so doing this now.