### PR TITLE
:construction_worker: Upgrade clang-tidy version on ubuntu

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,12 +78,6 @@ jobs:
       - name: 📡 Install linux default profiles
         run: conan config install -sf profiles/x86_64/linux/ -tf profiles https://github.com/libhal/conan-config.git
 
-      - name: 📡 Sign into JFrog Artifactory
-        env:
-          PASSWORD: ${{ secrets.JFROG_LIBHAL_TRUNK_ID_TOKEN }}
-          JFROG_USER: ${{ secrets.JFROG_LIBHAL_TRUNK_ID_TOKEN_USER }}
-        run: conan remote login -p $PASSWORD libhal $JFROG_USER
-
       - name: 📡 Install libhal settings_user.yml
         run: conan config install -sf profiles/baremetal/v2 https://github.com/libhal/conan-config.git
 
@@ -122,6 +116,13 @@ jobs:
 
       - name: 📦 Create `Release` package for ${{ inputs.profile }}
         run: conan create . -s build_type=Release -pr deploy.profile --version=${{ env.VERSION }}
+
+      - name: 📡 Sign into JFrog Artifactory
+        if: ${{ inputs.version != '' }}
+        env:
+          PASSWORD: ${{ secrets.JFROG_LIBHAL_TRUNK_ID_TOKEN }}
+          JFROG_USER: ${{ secrets.JFROG_LIBHAL_TRUNK_ID_TOKEN_USER }}
+        run: conan remote login -p $PASSWORD libhal $JFROG_USER
 
       - name: 🆙 Upload package version ${{ inputs.version }} to `libhal` repo
         if: ${{ inputs.version != '' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
             compiler_version: 12
             os: ubuntu-22.04
             standard_library: libstdc++
-            installations: sudo apt install -y clang-tidy-15
+            installations: sudo apt remove clang-tidy && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && sudo add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" && sudo apt install clang-tidy-17 && sudo ln -sf $(which clang-tidy-17) /usr/bin/clang-tidy
             enable_coverage: ${{ inputs.coverage }}
             profile_path: profiles/x86_64/linux/
 


### PR DESCRIPTION
This way clang-tidy will be used on the ubuntu build.