### PR TITLE
:green_heart: Remove version badge

### DIFF
--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Khalil Estell
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,9 +44,6 @@ jobs:
         with:
           path: docs
 
-      - name: Generate Latest Version Badge
-        run: wget "https://img.shields.io/badge/Latest%20Version-$(conan inspect . | grep version | cut -c 10- | sed s/-/~/ )-green" -O docs/latest_version.svg
-
       - name: Setup Pages
         uses: actions/configure-pages@v4.0.0
 


### PR DESCRIPTION
The version badge is no longer useful because we are using github releases which provides far more information about the code versions.

This can be replaced with something like this:

![GitHub Release](https://img.shields.io/github/v/release/libhal/libhal)

Created from: https://shields.io/badges/git-hub-release