### PR TITLE
:green_heart: Remove doc/ download in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,10 +40,6 @@ jobs:
       - name: 📥 Install Conan
         run: pip install conan
 
-      - uses: actions/download-artifact@v4.1.3
-        with:
-          path: docs
-
       - name: Setup Pages
         uses: actions/configure-pages@v4.0.0
 


### PR DESCRIPTION
We no longer upload libhal APIs on a per repo basis, instead we collect the APIs in the libhal.github.io page. This currently breaks publish.yml.