### PR TITLE
:sparkles: Add deploy_linux

### DIFF
--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -33,19 +33,14 @@ on:
         default: "2.2.2"
 
 jobs:
-  # linux_x86_64_gcc:
-  #   uses: ./.github/workflows/deploy.yml
-  #   with:
-  #     library: ${{ inputs.library }}
-  #     repo: ${{ inputs.repo }}
-  #     version: ${{ inputs.version }}
-  #     conan_version: ${{ inputs.conan_version }}
-  #     compiler: gcc
-  #     compiler_version: 12.3
-  #     compiler_package: ""
-  #     arch: x86_64
-  #     os: Linux
-  #   secrets: inherit
+  linux_x86_64_clang:
+    uses: ./.github/workflows/deploy_linux.yml
+    with:
+      library: ${{ inputs.library }}
+      repo: ${{ inputs.repo }}
+      version: ${{ inputs.version }}
+      conan_version: ${{ inputs.conan_version }}
+    secrets: inherit
   cortex-m0:
     uses: ./.github/workflows/deploy.yml
     with:

--- a/.github/workflows/deploy_linux.yml
+++ b/.github/workflows/deploy_linux.yml
@@ -1,0 +1,104 @@
+# Copyright 2024 Khalil Estell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Package 📦 + 🚀 Deploy
+
+on:
+  workflow_call:
+    inputs:
+      library:
+        type: string
+        default: ${{ github.event.repository.name }}
+      repo:
+        type: string
+        default: ${{ github.repository }}
+      conan_version:
+        type: string
+        default: "2.2.2"
+      version:
+        type: string
+        default: ""
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4.1.1
+        if: ${{ inputs.version != '' }}
+        with:
+          submodules: true
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.version }}
+
+      - uses: actions/checkout@v4.1.1
+        if: ${{ inputs.version == '' }}
+        with:
+          submodules: true
+          repository: ${{ inputs.repo }}
+
+      - name: 📥 Install Conan ${{ inputs.conan_version }}
+        run: pip3 install conan==${{ inputs.conan_version }}
+
+      - name: 📥 Install OS Specific Tools
+        run: sudo apt remove clang-tidy && wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 17 && sudo apt install libc++-17-dev libc++abi-17-dev
+
+      - name: 📡 Install default linux profiles
+        run: conan config install -sf profiles/x86_64/linux/ -tf profiles https://github.com/libhal/conan-config.git
+
+      - name: 📡 Add `libhal` repo to conan remotes
+        run: conan remote add libhal
+          https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
+
+      - name: 📡 Create and setup default profile
+        run: conan profile detect --force
+
+      - name: 👁️‍🗨️ Show conan profile
+        run: conan profile show
+
+      - name: 📡 Install linux default profiles
+        run: conan config install -sf profiles/x86_64/linux/ -tf profiles https://github.com/libhal/conan-config.git
+
+      - name: 📡 Install libhal settings_user.yml
+        run: conan config install -sf profiles/baremetal/v2 https://github.com/libhal/conan-config.git
+
+      - name: Set Version Environment Variable
+        run: |
+          if [ -z "${{ inputs.version }}" ]; then
+            echo "VERSION=latest" >> $GITHUB_ENV
+          else
+            echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+          fi
+
+      - name: 📦 Create `Debug` package for ${{ inputs.profile }}
+        run: conan create . -s build_type=Debug --version=${{ env.VERSION }}
+
+      - name: 📦 Create `RelWithDebInfo` package for ${{ inputs.profile }}
+        run: conan create . -s build_type=RelWithDebInfo --version=${{ env.VERSION }}
+
+      - name: 📦 Create `MinSizeRel` package for ${{ inputs.profile }}
+        run: conan create . -s build_type=MinSizeRel --version=${{ env.VERSION }}
+
+      - name: 📦 Create `Release` package for ${{ inputs.profile }}
+        run: conan create . -s build_type=Release --version=${{ env.VERSION }}
+
+      - name: 📡 Sign into JFrog Artifactory
+        if: ${{ inputs.version != '' }}
+        env:
+          PASSWORD: ${{ secrets.JFROG_LIBHAL_TRUNK_ID_TOKEN }}
+          JFROG_USER: ${{ secrets.JFROG_LIBHAL_TRUNK_ID_TOKEN_USER }}
+        run: conan remote login -p $PASSWORD libhal $JFROG_USER
+
+      - name: 🆙 Upload package version ${{ inputs.version }} to `libhal` repo
+        if: ${{ inputs.version != '' }}
+        run: conan upload "${{ inputs.library }}/${{ inputs.version }}" --confirm -r=libhal

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -51,12 +51,12 @@ jobs:
       repo: libhal/libhal-lpc40
     secrets: inherit
 
-  # libhal-soft:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-soft
-  #     repo: libhal/libhal-soft
-  #   secrets: inherit
+  libhal-soft:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-soft
+      repo: libhal/libhal-soft
+    secrets: inherit
 
   libhal-lpc4072:
     uses: ./.github/workflows/deploy.yml
@@ -92,6 +92,13 @@ jobs:
       compiler: gcc
       compiler_version: 12.3
       compiler_package: arm-gnu-toolchain
+    secrets: inherit
+
+  libhal-deploy-linux:
+    uses: ./.github/workflows/deploy_linux.yml
+    with:
+      library: libhal
+      repo: libhal/libhal
     secrets: inherit
 
   libhal-util-package:


### PR DESCRIPTION
deploy_linux.yml is used for header only libraries and CI to be able to match the github actions OS and settings to what is used in conan-config.

Update README.md to be mostly up to date.