### PR TITLE
:sparkles: Add support for external packages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,20 +44,23 @@ on:
       os:
         type: string
         required: true
+      external_package:
+        type: boolean
+        default: false
 
 jobs:
   deploy:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4.1.1
-        if: ${{ inputs.version != '' }}
+        if: ${{ inputs.version != '' && inputs.external_package == false}}
         with:
           submodules: true
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.version }}
 
       - uses: actions/checkout@v4.1.1
-        if: ${{ inputs.version == '' }}
+        if: ${{ inputs.version == '' || inputs.external_package == true}}
         with:
           submodules: true
           repository: ${{ inputs.repo }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,22 +14,22 @@ race, religion, or sexual identity and orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-*   Using welcoming and inclusive language
-*   Being respectful of differing viewpoints and experiences
-*   Gracefully accepting constructive criticism
-*   Focusing on what is best for the community
-*   Showing empathy towards other community members
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-*   The use of sexualized language or imagery and unwelcome sexual attention or
-    advances
-*   Trolling, insulting/derogatory comments, and personal or political attacks
-*   Public or private harassment
-*   Publishing others' private information, such as a physical or electronic
-    address, without explicit permission
-*   Other conduct which could reasonably be considered inappropriate in a
-    professional setting
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
 ## Our Responsibilities
 
@@ -68,13 +68,6 @@ and easily, and this gives people more control over the outcome of their
 dispute. If you are unable to resolve the matter for any reason, or if the
 behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
-
-Reports should be directed to the libhal email. It is the Project Steward’s duty to
-receive and address reported violations of the code of conduct. They will then
-work with a committee consisting of representatives from the Open Source
-Programs Office and the Google Open Source Strategy team. If for any reason you
-are uncomfortable reaching out to the Project Steward, please email
-libembeddedhal@google.com.
 
 We will investigate every complaint, but you may not receive a direct response.
 We will use our discretion in determining when and how to follow up on reported


### PR DESCRIPTION
deploy.yml will now accept an "external_package" input which, when set to 'true' will clone the repo from main and not from a release tag reference. This is useful for projects where we are just supporting a conan package of a package and not creating the releases ourselves.