### PR TITLE
:construction_worker: Remove conan create for demo builds

### DIFF
--- a/.github/workflows/demo_builder.yml
+++ b/.github/workflows/demo_builder.yml
@@ -87,8 +87,5 @@ jobs:
       - name: Install platform profiles
         run: conan config install -tf profiles -sf conan/profiles --args "-b ${{ inputs.platform_profile_branch }} --single-branch" ${{ inputs.platform_profile_url }}
 
-      - name: 📦 Build package using ${{ inputs.profile }}
-        run: conan create . -pr ${{ inputs.compiler_profile }} -pr ${{ inputs.platform_profile }} --version=latest
-
       - name: 🏗️ Build demos for ${{ inputs.profile }}
         run: conan build demos -pr ${{ inputs.compiler_profile }} -pr ${{ inputs.platform_profile }}


### PR DESCRIPTION
I realize that it was a mistake to build the current packages before building demos. Devs will attempt to clone our repo and build our demos, but may fail if a new demo using new features is added to the list. To ensure that this cannot happen, the current package is not built and the demo must be built using whats available on the conan repo.