### PR TITLE
:construction_worker: Removing macOS 13 from tests (#68)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,9 +51,6 @@ jobs:
           - os: ubuntu-24.04
             profile_path: profiles/x86_64/linux/
 
-          - os: macos-13
-            profile_path: profiles/x86_64/mac-13/
-
           - os: macos-14
             profile_path: profiles/x86_64/mac-14/
 
@@ -107,15 +104,6 @@ jobs:
           sudo apt-get install pipx
           pipx ensurepath
           sudo apt install clang-tidy-17
-
-      - name: 📥 Install OS Specific Tools (macos-13)
-        if: ${{ matrix.os == 'macos-13' }}
-        run: |
-          brew install llvm@17
-          ls $(brew --prefix llvm@17)/bin
-          ln -s $(brew --prefix llvm@17)/bin/clang-tidy /usr/local/bin/
-          brew install pipx
-          pipx ensurepath
 
       - name: 📥 Install OS Specific Tools (macos-14)
         if: ${{ matrix.os == 'macos-14' }}


### PR DESCRIPTION
For some reason, `std::pmr::memory_resource` does not link on macOS 13. Rather than try to support an older version of mac, I am removing macOS 13 from the tests. We may bring back support and investigate fixing the pmr issue if there is demand for it.