### PR TITLE
:technologist: env:VERBOSE=1 in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-24.04
+    env:
+      VERBOSE: 1
     steps:
       - uses: actions/checkout@v4.1.1
         if: ${{ inputs.version != '' && inputs.external_package == false}}


### PR DESCRIPTION
With this, we will now be able to see VERBOSE output from the conan build allowing us to find problems in the build such as missing command arguments.