### PR TITLE
[skip ci] :green_heart: Use -B for api.py checkout

### DIFF
--- a/.github/workflows/api_docs_gen.yml
+++ b/.github/workflows/api_docs_gen.yml
@@ -29,7 +29,7 @@ jobs:
       - run: sudo apt install -y doxygen
       - run: wget https://raw.githubusercontent.com/libhal/ci/5.x.y/scripts/api.py
       - run: wget https://raw.githubusercontent.com/libhal/ci/5.x.y/scripts/api_py_requirements.txt
-      - run: pip install -r docs/requirements.txt gitpython requests
+      - run: pip install -r api_py_requirements.txt gitpython requests
       - run: python api.py build --version ${{ github.ref_name }}
       - run: python api.py deploy --version ${{ github.ref_name }} --repo-name ${{ github.event.repository.name }}
         env:

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -260,7 +260,7 @@ def create_pr_to_api_repo(
 
             # Checkout existing branch or create a new branch
             print(f"Switching to branch: {branch_name}")
-            api_repo.git.switch('-c', branch_name)
+            api_repo.git.checkout('-B', branch_name)
 
             # Create repo directory if it doesn't exist
             repo_dir = os.path.join(temp_dir, repo_name)
@@ -303,7 +303,6 @@ def create_pr_to_api_repo(
                 print("Adding remote 'origin' with access token")
                 origin = api_repo.create_remote("origin", auth_url)
 
-            # Push the branch
             print(f"Pushing branch to remote...")
             api_repo.git.push('--set-upstream', 'origin', branch_name)
 


### PR DESCRIPTION
This should alleviate the errors we get when the branch already exists:

```
Run python api.py deploy --version main --repo-name libhal-arm-mcu
Cloning https://github.com/libhal/api.git into temporary directory...
Switching to branch: libhal-arm-mcu-main
Copying documentation from build/api/main to /tmp/tmpmafte93g/libhal-arm-mcu/main
Generated switcher.json for libhal-arm-mcu with 3 versions
Updating API repo's 'origin' to use access token
Pushing branch to remote...
Git error: Cmd('git') failed due to: exit code(1)
  cmdline: git push --set-upstream origin libhal-arm-mcu-main
  stderr: 'To https://github.com/libhal/api.git
 ! [rejected]        libhal-arm-mcu-main -> libhal-arm-mcu-main (non-fast-forward)
error: failed to push some refs to 'https://github.com/libhal/api.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. If you want to integrate the remote changes,
hint: use 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.'
```