### PR TITLE
:bug: Remove x86_64 mac from deploy all

### DIFF
--- a/.github/workflows/deploy_mac.yml
+++ b/.github/workflows/deploy_mac.yml
@@ -37,12 +37,6 @@ jobs:
       matrix:
         include:
           - os: macos-14
-            profile_path: profiles/x86_64/mac-14/
-
-          - os: macos-15
-            profile_path: profiles/x86_64/mac-15/
-
-          - os: macos-14
             profile_path: profiles/armv8/mac-14/
 
           - os: macos-15


### PR DESCRIPTION
Turns out that those mac images are ARM64 already binary we are building will break on x86_64.