### PR TITLE
:sparkles: (minor) Add dir support to all workflows

### DIFF
--- a/.github/workflows/demo_builder.yml
+++ b/.github/workflows/demo_builder.yml
@@ -47,6 +47,10 @@ on:
       platform_profile_branch:
         type: string
         default: "main"
+      # Directory where the conan package exists
+      dir:
+        type: string
+        default: "."
 
 jobs:
   build:
@@ -88,4 +92,4 @@ jobs:
         run: conan config install -tf profiles -sf conan/profiles --args "-b ${{ inputs.platform_profile_branch }} --single-branch" ${{ inputs.platform_profile_url }}
 
       - name: 🏗️ Build demos for ${{ inputs.profile }}
-        run: conan build demos -pr ${{ inputs.compiler_profile }} -pr ${{ inputs.platform_profile }}
+        run: conan build ${{ inputs.dir }}/demos -pr ${{ inputs.compiler_profile }} -pr ${{ inputs.platform_profile }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,10 @@ on:
       external_package:
         type: boolean
         default: false
+      # Directory where the conan package exists
+      dir:
+        type: string
+        default: "."
 
 jobs:
   deploy:
@@ -69,15 +73,8 @@ jobs:
 
       - name: 📥 Install OS Specific Tools
         run: |
-          sudo apt remove clang-tidy
-          sudo rm -f /usr/bin/clang-tidy
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 17
-          sudo apt install libc++-17-dev libc++abi-17-dev
           sudo apt-get install pipx
           pipx ensurepath
-          sudo apt install clang-tidy-17
 
       - name: 📥 Install Conan ${{ inputs.conan_version }}
         run: pipx install conan==${{ inputs.conan_version }}
@@ -123,16 +120,16 @@ jobs:
           echo "${{ inputs.compiler_package }}/${{ inputs.compiler_version }}" >> deploy.profile
 
       - name: 📦 Create `Debug` package for ${{ inputs.profile }}
-        run: conan create . -s build_type=Debug -pr deploy.profile --version=${{ env.VERSION }}
+        run: conan create ${{ inputs.dir }} -s build_type=Debug -pr deploy.profile --version=${{ env.VERSION }}
 
       - name: 📦 Create `RelWithDebInfo` package for ${{ inputs.profile }}
-        run: conan create . -s build_type=RelWithDebInfo -pr deploy.profile --version=${{ env.VERSION }}
+        run: conan create ${{ inputs.dir }} -s build_type=RelWithDebInfo -pr deploy.profile --version=${{ env.VERSION }}
 
       - name: 📦 Create `MinSizeRel` package for ${{ inputs.profile }}
-        run: conan create . -s build_type=MinSizeRel -pr deploy.profile --version=${{ env.VERSION }}
+        run: conan create ${{ inputs.dir }} -s build_type=MinSizeRel -pr deploy.profile --version=${{ env.VERSION }}
 
       - name: 📦 Create `Release` package for ${{ inputs.profile }}
-        run: conan create . -s build_type=Release -pr deploy.profile --version=${{ env.VERSION }}
+        run: conan create ${{ inputs.dir }} -s build_type=Release -pr deploy.profile --version=${{ env.VERSION }}
 
       - name: 📡 Sign into JFrog Artifactory
         if: ${{ inputs.version != '' }}

--- a/.github/workflows/deploy_all.yml
+++ b/.github/workflows/deploy_all.yml
@@ -31,6 +31,10 @@ on:
       conan_version:
         type: string
         default: "2.16.1"
+      # Directory where the conan package exists
+      dir:
+        type: string
+        default: "."
 
 jobs:
   linux_x86_64_clang:
@@ -40,6 +44,7 @@ jobs:
       repo: ${{ inputs.repo }}
       version: ${{ inputs.version }}
       conan_version: ${{ inputs.conan_version }}
+      dir: ${{ inputs.dir }}
     secrets: inherit
   mac_os_x:
     uses: ./.github/workflows/deploy_mac.yml
@@ -48,6 +53,7 @@ jobs:
       repo: ${{ inputs.repo }}
       version: ${{ inputs.version }}
       conan_version: ${{ inputs.conan_version }}
+      dir: ${{ inputs.dir }}
     secrets: inherit
   cortex-m0:
     uses: ./.github/workflows/deploy.yml
@@ -56,6 +62,7 @@ jobs:
       repo: ${{ inputs.repo }}
       version: ${{ inputs.version }}
       conan_version: ${{ inputs.conan_version }}
+      dir: ${{ inputs.dir }}
       compiler: gcc
       compiler_version: 12.3
       compiler_package: arm-gnu-toolchain
@@ -69,6 +76,7 @@ jobs:
       repo: ${{ inputs.repo }}
       version: ${{ inputs.version }}
       conan_version: ${{ inputs.conan_version }}
+      dir: ${{ inputs.dir }}
       compiler: gcc
       compiler_version: 12.3
       compiler_package: arm-gnu-toolchain
@@ -82,6 +90,7 @@ jobs:
       repo: ${{ inputs.repo }}
       version: ${{ inputs.version }}
       conan_version: ${{ inputs.conan_version }}
+      dir: ${{ inputs.dir }}
       compiler: gcc
       compiler_version: 12.3
       compiler_package: arm-gnu-toolchain
@@ -95,6 +104,7 @@ jobs:
       repo: ${{ inputs.repo }}
       version: ${{ inputs.version }}
       conan_version: ${{ inputs.conan_version }}
+      dir: ${{ inputs.dir }}
       compiler: gcc
       compiler_version: 12.3
       compiler_package: arm-gnu-toolchain
@@ -108,6 +118,7 @@ jobs:
       repo: ${{ inputs.repo }}
       version: ${{ inputs.version }}
       conan_version: ${{ inputs.conan_version }}
+      dir: ${{ inputs.dir }}
       compiler: gcc
       compiler_version: 12.3
       compiler_package: arm-gnu-toolchain
@@ -121,6 +132,7 @@ jobs:
       repo: ${{ inputs.repo }}
       version: ${{ inputs.version }}
       conan_version: ${{ inputs.conan_version }}
+      dir: ${{ inputs.dir }}
       compiler: gcc
       compiler_version: 12.3
       compiler_package: arm-gnu-toolchain

--- a/.github/workflows/deploy_linux.yml
+++ b/.github/workflows/deploy_linux.yml
@@ -29,6 +29,14 @@ on:
       version:
         type: string
         default: ""
+      # Version of LLVM to install via homebrew
+      llvm:
+        type: string
+        default: "17"
+      # Directory where the conan package exists
+      dir:
+        type: string
+        default: "."
 
 jobs:
   deploy:
@@ -53,11 +61,11 @@ jobs:
           sudo rm -f /usr/bin/clang-tidy
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 17
-          sudo apt install libc++-17-dev libc++abi-17-dev
+          sudo ./llvm.sh ${{ inputs.llvm }}
+          sudo apt install libc++-${{ inputs.llvm }}-dev libc++abi-${{ inputs.llvm }}-dev
           sudo apt-get install pipx
           pipx ensurepath
-          sudo apt install clang-tidy-17
+          sudo apt install clang-tidy-${{ inputs.llvm }}
 
       - name: 📥 Install Conan ${{ inputs.conan_version }}
         run: pipx install conan==${{ inputs.conan_version }}
@@ -90,16 +98,16 @@ jobs:
           fi
 
       - name: 📦 Create `Debug` package for ${{ inputs.profile }}
-        run: conan create . -s build_type=Debug --version=${{ env.VERSION }}
+        run: conan create ${{ inputs.dir }} -s build_type=Debug --version=${{ env.VERSION }}
 
       - name: 📦 Create `RelWithDebInfo` package for ${{ inputs.profile }}
-        run: conan create . -s build_type=RelWithDebInfo --version=${{ env.VERSION }}
+        run: conan create ${{ inputs.dir }} -s build_type=RelWithDebInfo --version=${{ env.VERSION }}
 
       - name: 📦 Create `MinSizeRel` package for ${{ inputs.profile }}
-        run: conan create . -s build_type=MinSizeRel --version=${{ env.VERSION }}
+        run: conan create ${{ inputs.dir }} -s build_type=MinSizeRel --version=${{ env.VERSION }}
 
       - name: 📦 Create `Release` package for ${{ inputs.profile }}
-        run: conan create . -s build_type=Release --version=${{ env.VERSION }}
+        run: conan create ${{ inputs.dir }} -s build_type=Release --version=${{ env.VERSION }}
 
       - name: 📡 Sign into JFrog Artifactory
         if: ${{ inputs.version != '' }}

--- a/.github/workflows/deploy_mac.yml
+++ b/.github/workflows/deploy_mac.yml
@@ -29,6 +29,14 @@ on:
       version:
         type: string
         default: ""
+      # Directory where the conan package exists
+      dir:
+        type: string
+        default: "."
+      # Version of LLVM to install via homebrew
+      llvm:
+        type: string
+        default: "17"
 
 jobs:
   deploy_all_mac:
@@ -60,16 +68,16 @@ jobs:
       - name: 📥 Install OS Specific Tools (macos-14)
         if: ${{ matrix.os == 'macos-14' }}
         run: |
-          brew install llvm@17
-          ln -s $(brew --prefix llvm@17)/bin/clang-tidy /usr/local/bin/
+          brew install llvm@${{ inputs.llvm }}
+          ln -s $(brew --prefix llvm@${{ inputs.llvm }})/bin/clang-tidy /usr/local/bin/
           brew install pipx
           pipx ensurepath
 
       - name: 📥 Install OS Specific Tools (macos-15)
         if: ${{ matrix.os == 'macos-15' }}
         run: |
-          brew install llvm@17
-          ln -s $(brew --prefix llvm@17)/bin/clang-tidy /usr/local/bin/
+          brew install llvm@${{ inputs.llvm }}
+          ln -s $(brew --prefix llvm@${{ inputs.llvm }})/bin/clang-tidy /usr/local/bin/
           brew install pipx
           pipx ensurepath
 
@@ -83,13 +91,13 @@ jobs:
         run: cmake --version
 
       - name: 🔍 clang++ version
-        run: clang++-17 --version || clang++ --version
+        run: clang++-${{ inputs.llvm }} --version || clang++ --version
 
       - name: 🔍 /usr/bin version
         run: ls /usr/bin/clang*
 
       - name: 🔍 clang-tidy version
-        run: clang-tidy-17 --version || clang-tidy --version
+        run: clang-tidy-${{ inputs.llvm }} --version || clang-tidy --version
 
       - name: 📡 Add `libhal` repo to conan remotes
         run: conan remote add libhal
@@ -122,16 +130,16 @@ jobs:
           fi
 
       - name: 📦 Create `Debug` package for ${{ inputs.profile }}
-        run: conan create . -pr mac-hal -s build_type=Debug --version=${{ env.VERSION }} -b missing
+        run: conan create ${{ inputs.dir }} -pr mac-hal -s build_type=Debug --version=${{ env.VERSION }} -b missing
 
       - name: 📦 Create `RelWithDebInfo` package for ${{ inputs.profile }}
-        run: conan create . -pr mac-hal -s build_type=RelWithDebInfo --version=${{ env.VERSION }} -b missing
+        run: conan create ${{ inputs.dir }} -pr mac-hal -s build_type=RelWithDebInfo --version=${{ env.VERSION }} -b missing
 
       - name: 📦 Create `MinSizeRel` package for ${{ inputs.profile }}
-        run: conan create . -pr mac-hal -s build_type=MinSizeRel --version=${{ env.VERSION }} -b missing
+        run: conan create ${{ inputs.dir }} -pr mac-hal -s build_type=MinSizeRel --version=${{ env.VERSION }} -b missing
 
       - name: 📦 Create `Release` package for ${{ inputs.profile }}
-        run: conan create . -pr mac-hal -s build_type=Release --version=${{ env.VERSION }} -b missing
+        run: conan create ${{ inputs.dir }} -pr mac-hal -s build_type=Release --version=${{ env.VERSION }} -b missing
 
       - name: 📡 Sign into JFrog Artifactory
         if: ${{ inputs.version != '' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,10 @@ on:
       version:
         type: string
         default: ""
+      # Directory where the conan package exists
+      dir:
+        type: string
+        required: true
 
 jobs:
   docs:

--- a/.github/workflows/library_check.yml
+++ b/.github/workflows/library_check.yml
@@ -41,6 +41,10 @@ on:
       conan_version:
         type: string
         default: "2.16.1"
+      # Directory where the conan package exists
+      dir:
+        type: string
+        default: "."
 
 jobs:
   tests:
@@ -53,6 +57,7 @@ jobs:
       fail_on_coverage: ${{ inputs.fail_on_coverage }}
       coverage_threshold: ${{ inputs.coverage_threshold }}
       conan_version: ${{ inputs.conan_version }}
+      dir: ${{ inputs.dir }}
     secrets: inherit
 
   lint:
@@ -62,6 +67,7 @@ jobs:
       version: ${{ inputs.version }}
       source_dir: ${{ inputs.source_dir }}
       repo: ${{ inputs.repo }}
+      dir: ${{ inputs.dir }}
     secrets: inherit
 
   docs:
@@ -71,4 +77,5 @@ jobs:
       version: ${{ inputs.version }}
       source_dir: ${{ inputs.source_dir }}
       repo: ${{ inputs.repo }}
+      dir: ${{ inputs.dir }}
     secrets: inherit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,10 @@ on:
       version:
         type: string
         default: ""
+      # Directory where the conan package exists
+      dir:
+        type: string
+        default: "."
 
 jobs:
   lint:

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -92,6 +92,7 @@ jobs:
     with:
       library: libhal-micromod
       source_dir: src
+      dir: src
       repo: libhal/libhal-micromod
     secrets: inherit
 
@@ -100,6 +101,7 @@ jobs:
     with:
       library: libhal-micromod
       source_dir: src
+      dir: src
       repo: libhal/libhal-micromod
     secrets: inherit
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,14 @@ on:
       conan_version:
         type: string
         required: true
-
+      # Directory where the conan package exists
+      dir:
+        type: string
+        default: "."
+      # Version of LLVM to install via homebrew
+      llvm:
+        type: string
+        default: "17"
 jobs:
   run_tests:
     strategy:
@@ -86,11 +93,11 @@ jobs:
           sudo rm -f /usr/bin/clang-tidy
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 17
-          sudo apt install libc++-17-dev libc++abi-17-dev
+          sudo ./llvm.sh ${{ inputs.llvm }}
+          sudo apt install libc++-${{ inputs.llvm }}-dev libc++abi-${{ inputs.llvm }}-dev
           sudo apt-get install pipx
           pipx ensurepath
-          sudo apt install clang-tidy-17
+          sudo apt install clang-tidy-${{ inputs.llvm }}
 
       - name: 📥 Install OS Specific Tools (ubuntu-24.04)
         if: ${{ matrix.os == 'ubuntu-24.04' }}
@@ -99,25 +106,25 @@ jobs:
           sudo rm -f /usr/bin/clang-tidy
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 17
-          sudo apt install libc++-17-dev libc++abi-17-dev
+          sudo ./llvm.sh ${{ inputs.llvm }}
+          sudo apt install libc++-${{ inputs.llvm }}-dev libc++abi-${{ inputs.llvm }}-dev
           sudo apt-get install pipx
           pipx ensurepath
-          sudo apt install clang-tidy-17
+          sudo apt install clang-tidy-${{ inputs.llvm }}
 
       - name: 📥 Install OS Specific Tools (macos-14)
         if: ${{ matrix.os == 'macos-14' }}
         run: |
-          brew install llvm@17
-          ln -s $(brew --prefix llvm@17)/bin/clang-tidy /usr/local/bin/
+          brew install llvm@${{ inputs.llvm }}
+          ln -s $(brew --prefix llvm@${{ inputs.llvm }})/bin/clang-tidy /usr/local/bin/
           brew install pipx
           pipx ensurepath
 
       - name: 📥 Install OS Specific Tools (macos-15)
         if: ${{ matrix.os == 'macos-15' }}
         run: |
-          brew install llvm@17
-          ln -s $(brew --prefix llvm@17)/bin/clang-tidy /usr/local/bin/
+          brew install llvm@${{ inputs.llvm }}
+          ln -s $(brew --prefix llvm@${{ inputs.llvm }})/bin/clang-tidy /usr/local/bin/
           brew install pipx
           pipx ensurepath
 
@@ -131,13 +138,13 @@ jobs:
         run: cmake --version
 
       - name: 🔍 clang++ version
-        run: clang++-17 --version || clang++ --version
+        run: clang++-${{ inputs.llvm }} --version || clang++ --version
 
       - name: 🔍 /usr/bin version
         run: ls /usr/bin/clang*
 
       - name: 🔍 clang-tidy version
-        run: clang-tidy-17 --version || clang-tidy --version
+        run: clang-tidy-${{ inputs.llvm }} --version || clang-tidy --version
 
       - name: 📡 Add `libhal` repo to conan remotes
         run: conan remote add libhal
@@ -161,47 +168,8 @@ jobs:
 
       - name: 🔬 Create & Run Unit Tests (Windows-MinSizeRel)
         if: ${{ runner.os == 'Windows' }}
-        run: $env:VERBOSE = 1 ; conan create . --build=missing -s build_type=MinSizeRel --version='latest'
+        run: $env:VERBOSE = 1 ; conan create ${{ inputs.dir }} --build=missing -s build_type=MinSizeRel --version='latest'
 
       - name: 🔬 Create & Run Unit Tests (Everything_Else-MinSizeRel)
         if: ${{ runner.os != 'Windows' }}
-        run: VERBOSE=1 conan create . --build=missing -s build_type=MinSizeRel --version="latest"
-
-      # ========================================================================
-      # DISABLE COVERAGE! Not sure if its worth it to support it as a part of CI
-      # ========================================================================
-
-      # - name: 🔬 Build & Run Unit Tests (for coverage Debug)
-      #   if: ${{ matrix.enable_coverage }}
-      #   run: VERBOSE=1 conan build . --build=missing -s build_type=Debug --version="latest"
-
-      # - name: 📥 Install gcovr
-      #   if: ${{ matrix.enable_coverage }}
-      #   run: pipx install gcovr
-
-      # - name: 🔎 Generate Code Coverage
-      #   if: ${{ matrix.enable_coverage }}
-      #   working-directory: build
-      #   run: |
-      #     mkdir coverage/ && python3 -m gcovr --root ../../ --exclude ".*/third_party/.*" --cobertura coverage/coverage.xml --html coverage/index.html --html-details --sort-percentage
-
-      # - name: Coverage Summary
-      #   if: ${{ matrix.enable_coverage }}
-      #   uses: irongut/CodeCoverageSummary@v1.3.0
-      #   with:
-      #     filename: build/coverage/coverage.xml
-      #     badge: true
-      #     fail_below_min: ${{ inputs.fail_on_coverage }}
-      #     format: markdown
-      #     hide_branch_rate: false
-      #     hide_complexity: true
-      #     indicators: true
-      #     output: both
-      #     thresholds: ${{ inputs.coverage_threshold }}
-
-      # - name: Extract & Save Coverage SVG
-      #   if: ${{ matrix.enable_coverage }}
-      #   run: wget
-      #     $(cat code-coverage-results.md |
-      #     grep -Eo 'https://img.shields.io/badge/[^)]*')
-      #     -O build/coverage/coverage.svg
+        run: VERBOSE=1 conan create ${{ inputs.dir }} --build=missing -s build_type=MinSizeRel --version="latest"


### PR DESCRIPTION
Each appropriate workflow now has a `dir` input which controls which directory is used to locate the conanfile.py such as `v4/` and `v5/`.