### PR TITLE
🚧 Refactor CI workflows to use Conan 2.23.0 and consolidate builds

### DIFF
--- a/.github/workflows/app_builder2.yml
+++ b/.github/workflows/app_builder2.yml
@@ -25,7 +25,7 @@ on:
         default: ""
       conan_version:
         type: string
-        default: "2.16.1"
+        default: "2.23.0"
       compiler_profile:
         type: string
         required: true
@@ -59,18 +59,11 @@ jobs:
       - name: 📥 Install Conan ${{ inputs.conan_version }}
         run: pipx install conan==${{ inputs.conan_version }}
 
-      - name: 📡 Add `libhal` repo to conan remotes
-        run: conan remote add libhal
-          https://libhal.jfrog.io/artifactory/api/conan/trunk-conan
-
-      - name: 📡 Create and setup default profile
-        run: conan profile detect --force
-
-      - name: 👁️‍🗨️ Show conan profile
-        run: conan profile show
-
       - name: Install libhal conan config
         run: conan config install https://github.com/libhal/conan-config2.git --args="-b ${{ inputs.config2_version }}"
+
+      - name: Setup libhal
+        run: conan hal setup
 
       - name: 🏗️ Build Application for ${{ inputs.profile }}
         run: conan build ${{ inputs.dir }} -pr ${{ inputs.compiler_profile }} -pr ${{ inputs.platform_profile }}

--- a/.github/workflows/package_and_upload_all.yml
+++ b/.github/workflows/package_and_upload_all.yml
@@ -37,6 +37,9 @@ on:
       remote_url:
         type: string
         default: ""
+      modules_support_needed:
+        type: boolean
+        default: False
 
     secrets:
       conan_remote_password:
@@ -102,293 +105,113 @@ jobs:
       conan_remote_user: ${{ secrets.conan_remote_user }}
       conan_remote_password: ${{ secrets.conan_remote_password }}
 
-  # # ==========================================================================
-  # # Disabled: Executing unit test binaries seg fault
-  # # ==========================================================================
-  # # TODO(#95): Enable Windows
-  # windows_arm_llvm:
-  #   uses: ./.github/workflows/package_and_upload.yml
-  #   with:
-  #     # Target specific
-  #     runner_os: windows-11-arm
-  #     arch: armv8
-  #     os: Windows
-  #     compiler_profile: hal/tc/llvm
-  #     # Plumbing
-  #     library: ${{ inputs.library }}
-  #     repo: ${{ inputs.repo }}
-  #     conan_version: ${{ inputs.conan_version }}
-  #     dir: ${{ inputs.dir }}
-  #     remote_url: ${{ inputs.remote_url }}
-  #   secrets:
-  #     conan_remote_user: ${{ secrets.conan_remote_user }}
-  #     conan_remote_password: ${{ secrets.conan_remote_password }}
+  # ================ ARM CORTEX LLVM ================
 
-  # # ==========================================================================
-  # # Disabled: Executing unit test binaries seg fault
-  # # ==========================================================================
-  # # TODO(#95): Enable Windows
-  # windows_x86_64_llvm:
-  #   uses: ./.github/workflows/package_and_upload.yml
-  #   with:
-  #     # Target specific
-  #     runner_os: windows-latest
-  #     arch: x86_64
-  #     os: Windows
-  #     compiler_profile: hal/tc/llvm
-  #     # Plumbing
-  #     library: ${{ inputs.library }}
-  #     repo: ${{ inputs.repo }}
-  #     conan_version: ${{ inputs.conan_version }}
-  #     dir: ${{ inputs.dir }}
-  #     remote_url: ${{ inputs.remote_url }}
-  #   secrets:
-  #     conan_remote_user: ${{ secrets.conan_remote_user }}
-  #     conan_remote_password: ${{ secrets.conan_remote_password }}
+  cortex-m_llvm:
+    runs-on: ubuntu-latest
+    env:
+      VERBOSE: 1
+      CONAN_REMOTE_USER: ${{ secrets.conan_remote_user }}
+      CONAN_REMOTE_PASSWORD: ${{ secrets.conan_remote_password }}
+    steps:
+      - name: 📥 Checkout target repository
+        uses: actions/checkout@v4.1.1
+        if: ${{ inputs.version != 'latest' }}
+        with:
+          submodules: true
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.version }}
+          path: target-repo
 
-  cortex-m0plus:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m0plus
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 📥 Checkout target repository (latest)
+        uses: actions/checkout@v4.1.1
+        if: ${{ inputs.version == 'latest' }}
+        with:
+          submodules: true
+          repository: ${{ inputs.repo }}
+          path: target-repo
 
-  cortex-m1:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m1
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 📥 Checkout CI repository for scripts
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: libhal/ci
+          ref: ${{ github.workflow_sha }}
+          path: ci-repo
 
-  cortex-m3:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m3
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 📦 Build packages for all Cortex-M architectures
+        working-directory: target-repo
+        run: |
+          bash ../ci-repo/scripts/baremetal_package.sh \
+            --dir ${{ inputs.dir }} \
+            --version ${{ inputs.version }} \
+            --compiler-profile hal/tc/llvm \
+            --conan-version ${{ inputs.conan_version }} \
+            --arch-list cortex-m0,cortex-m0plus,cortex-m1,cortex-m3,cortex-m4,cortex-m4f,cortex-m7f,cortex-m7d,cortex-m23,cortex-m33,cortex-m33f,cortex-m35pf,cortex-m55,cortex-m85
 
-  cortex-m4:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m4
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 📡 Add conan user remote-package-repo
+        if: ${{ inputs.remote_url != '' }}
+        run: conan remote add --force remote-package-repo ${{ inputs.remote_url }}
 
-  cortex-m4f:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m4f
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 📡 Sign into Conan Package Repository
+        if: ${{ inputs.version != 'latest' && inputs.remote_url != '' && env.CONAN_REMOTE_USER != '' && env.CONAN_REMOTE_PASSWORD != '' }}
+        run: conan remote login -p ${{ secrets.conan_remote_password }} remote-package-repo ${{ secrets.conan_remote_user }}
 
-  cortex-m7f:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m7f
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 🆙 Upload package version ${{ inputs.version }} to conan repo
+        if: ${{ inputs.version != 'latest' && inputs.remote_url != '' }}
+        run: conan upload "${{ inputs.library }}/${{ inputs.version }}" --confirm -r=remote-package-repo
 
-  cortex-m7d:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m7d
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+  # ================ ARM CORTEX GCC ================
 
-  cortex-m23:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m23
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+  cortex-m_gcc:
+    runs-on: ubuntu-latest
+    if: ${{ inputs.modules_support_needed == false }}
+    env:
+      VERBOSE: 1
+      CONAN_REMOTE_USER: ${{ secrets.conan_remote_user }}
+      CONAN_REMOTE_PASSWORD: ${{ secrets.conan_remote_password }}
+    steps:
+      - name: 📥 Checkout target repository
+        uses: actions/checkout@v4.1.1
+        if: ${{ inputs.version != 'latest' }}
+        with:
+          submodules: true
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.version }}
+          path: target-repo
 
-  cortex-m33:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m33
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 📥 Checkout target repository (latest)
+        uses: actions/checkout@v4.1.1
+        if: ${{ inputs.version == 'latest' }}
+        with:
+          submodules: true
+          repository: ${{ inputs.repo }}
+          path: target-repo
 
-  cortex-m33f:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m33f
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 📥 Checkout CI repository for scripts
+        uses: actions/checkout@v4.1.1
+        with:
+          repository: libhal/ci
+          ref: ${{ github.workflow_sha }}
+          path: ci-repo
 
-  cortex-m35pf:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m35pf
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 📦 Build packages for all Cortex-M architectures
+        working-directory: target-repo
+        run: |
+          bash ../ci-repo/scripts/baremetal_package.sh \
+            --dir ${{ inputs.dir }} \
+            --version ${{ inputs.version }} \
+            --compiler-profile hal/tc/arm-gcc \
+            --conan-version ${{ inputs.conan_version }} \
+            --arch-list cortex-m0,cortex-m0plus,cortex-m1,cortex-m3,cortex-m4,cortex-m4f,cortex-m7f,cortex-m7d,cortex-m23,cortex-m33,cortex-m33f,cortex-m35pf,cortex-m55,cortex-m85
 
-  cortex-m55:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m55
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 📡 Add conan user remote-package-repo
+        if: ${{ inputs.remote_url != '' }}
+        run: conan remote add --force remote-package-repo ${{ inputs.remote_url }}
 
-  cortex-m85:
-    uses: ./.github/workflows/package_and_upload.yml
-    with:
-      # Target specific
-      runner_os: ubuntu-24.04
-      arch: cortex-m85
-      os: baremetal
-      compiler_profile: hal/tc/llvm
-      # Plumbing
-      library: ${{ inputs.library }}
-      repo: ${{ inputs.repo }}
-      conan_version: ${{ inputs.conan_version }}
-      version: ${{ inputs.version }}
-      dir: ${{ inputs.dir }}
-      remote_url: ${{ inputs.remote_url }}
-    secrets:
-      conan_remote_user: ${{ secrets.conan_remote_user }}
-      conan_remote_password: ${{ secrets.conan_remote_password }}
+      - name: 📡 Sign into Conan Package Repository
+        if: ${{ inputs.version != 'latest' && inputs.remote_url != '' && env.CONAN_REMOTE_USER != '' && env.CONAN_REMOTE_PASSWORD != '' }}
+        run: conan remote login -p ${{ secrets.conan_remote_password }} remote-package-repo ${{ secrets.conan_remote_user }}
+
+      - name: 🆙 Upload package version ${{ inputs.version }} to conan repo
+        if: ${{ inputs.version != 'latest' && inputs.remote_url != '' }}
+        run: conan upload "${{ inputs.library }}/${{ inputs.version }}" --confirm -r=remote-package-repo

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -79,30 +79,29 @@ jobs:
   #     repo: libhal/libhal-micromod
   #   secrets: inherit
 
-  package-strong_ptr:
-    uses: ./.github/workflows/package_and_upload_all.yml
-    with:
-      library: strong_ptr
-      repo: libhal/strong_ptr
-      modules_support_needed: true
-    secrets: inherit
+  # package-strong_ptr:
+  #   uses: ./.github/workflows/package_and_upload_all.yml
+  #   with:
+  #     library: strong_ptr
+  #     repo: libhal/strong_ptr
+  #     modules_support_needed: true
+  #   secrets: inherit
 
-  package-libhal_v4:
-    uses: ./.github/workflows/package_and_upload_all.yml
-    with:
-      library: libhal
-      repo: libhal/libhal
-      dir: v4
-    secrets: inherit
+  # package-libhal_v4:
+  #   uses: ./.github/workflows/package_and_upload_all.yml
+  #   with:
+  #     library: libhal
+  #     repo: libhal/libhal
+  #     dir: v4
+  #   secrets: inherit
 
-  package-libhal-util:
-    uses: ./.github/workflows/package_and_upload_all.yml
-    with:
-      library: libhal-util
-      repo: libhal/libhal-util
-      modules_support_needed: true
-      dir: v5
-    secrets: inherit
+  # package-libhal-util:
+  #   uses: ./.github/workflows/package_and_upload_all.yml
+  #   with:
+  #     library: libhal-util
+  #     repo: libhal/libhal-util
+  #     dir: v5
+  #   secrets: inherit
 
   # TODO(#95): Enable Windows
   # TODO(libhal/async_context#17): Add async-context
@@ -114,48 +113,48 @@ jobs:
     with:
       repo: libhal/libhal-arm-mcu
       dir: demos
-      compiler_profile: hal/tc/arm-gcc-12.3
+      compiler_profile: hal/tc/arm-gcc
       platform_profile: hal/mcu/lpc4078
     secrets: inherit
 
-  libhal-actuator-demos-lpc4078:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-actuator
-      dir: demos
-      compiler_profile: hal/tc/arm-gcc-12.3
-      platform_profile: hal/mcu/lpc4078
-    secrets: inherit
+  # libhal-actuator-demos-lpc4078:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-actuator
+  #     dir: demos
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4078
+  #   secrets: inherit
 
-  libhal-actuator-demos-lpc4074:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-actuator
-      dir: demos
-      compiler_profile: hal/tc/arm-gcc-12.3
-      platform_profile: hal/mcu/lpc4074
-    secrets: inherit
+  # libhal-actuator-demos-lpc4074:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-actuator
+  #     dir: demos
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4074
+  #   secrets: inherit
 
-  libhal-starter-app-lpc4078:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-starter
-      compiler_profile: hal/tc/arm-gcc-12.3
-      platform_profile: hal/mcu/lpc4078
-    secrets: inherit
+  # libhal-starter-app-lpc4078:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-starter
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4078
+  #   secrets: inherit
 
-  libhal-starter-app-stm32f103c8:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-starter
-      compiler_profile: hal/tc/arm-gcc-12.3
-      platform_profile: hal/mcu/stm32f103c8
-    secrets: inherit
+  # libhal-starter-app-stm32f103c8:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-starter
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/stm32f103c8
+  #   secrets: inherit
 
-  libhal-starter-app-mod-stmt32f1-v4:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-starter
-      compiler_profile: hal/tc/arm-gcc-12.3
-      platform_profile: hal/bsp/mod-stm32f1-v4
-    secrets: inherit
+  # libhal-starter-app-mod-stmt32f1-v4:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-starter
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/bsp/mod-stm32f1-v4
+  #   secrets: inherit

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -24,66 +24,67 @@ on:
   workflow_dispatch:
 
 jobs:
-  library_check_libhal_v4:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal
-      repo: libhal/libhal
-      dir: v4
-    secrets: inherit
+  # library_check_libhal_v4:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal
+  #     repo: libhal/libhal
+  #     dir: v4
+  #   secrets: inherit
 
-  library_check_libhal-util:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-util
-      repo: libhal/libhal-util
-      dir: v5
-    secrets: inherit
+  # library_check_libhal-util:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-util
+  #     repo: libhal/libhal-util
+  #     dir: v5
+  #   secrets: inherit
 
-  libhal-actuator:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-actuator
-      repo: libhal/libhal-actuator
-    secrets: inherit
+  # libhal-actuator:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-actuator
+  #     repo: libhal/libhal-actuator
+  #   secrets: inherit
 
-  libhal-sensor:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-sensor
-      repo: libhal/libhal-sensor
-    secrets: inherit
+  # libhal-sensor:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-sensor
+  #     repo: libhal/libhal-sensor
+  #   secrets: inherit
 
-  libhal-expander:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-expander
-      repo: libhal/libhal-expander
-    secrets: inherit
+  # libhal-expander:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-expander
+  #     repo: libhal/libhal-expander
+  #   secrets: inherit
 
-  libhal-micromod-lint:
-    uses: ./.github/workflows/lint.yml
-    with:
-      library: libhal-micromod
-      source_dir: src
-      dir: .
-      repo: libhal/libhal-micromod
-    secrets: inherit
+  # libhal-micromod-lint:
+  #   uses: ./.github/workflows/lint.yml
+  #   with:
+  #     library: libhal-micromod
+  #     source_dir: src
+  #     dir: .
+  #     repo: libhal/libhal-micromod
+  #   secrets: inherit
 
-  libhal-micromod-docs:
-    uses: ./.github/workflows/docs.yml
-    with:
-      library: libhal-micromod
-      source_dir: src
-      dir: .
-      repo: libhal/libhal-micromod
-    secrets: inherit
+  # libhal-micromod-docs:
+  #   uses: ./.github/workflows/docs.yml
+  #   with:
+  #     library: libhal-micromod
+  #     source_dir: src
+  #     dir: .
+  #     repo: libhal/libhal-micromod
+  #   secrets: inherit
 
   package-strong_ptr:
     uses: ./.github/workflows/package_and_upload_all.yml
     with:
       library: strong_ptr
       repo: libhal/strong_ptr
+      modules_support_needed: true
     secrets: inherit
 
   package-libhal_v4:
@@ -99,6 +100,7 @@ jobs:
     with:
       library: libhal-util
       repo: libhal/libhal-util
+      modules_support_needed: true
       dir: v5
     secrets: inherit
 

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -24,84 +24,84 @@ on:
   workflow_dispatch:
 
 jobs:
-  # library_check_libhal_v4:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal
-  #     repo: libhal/libhal
-  #     dir: v4
-  #   secrets: inherit
+  library_check_libhal_v4:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal
+      repo: libhal/libhal
+      dir: v4
+    secrets: inherit
 
-  # library_check_libhal-util:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-util
-  #     repo: libhal/libhal-util
-  #     dir: v5
-  #   secrets: inherit
+  library_check_libhal-util:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-util
+      repo: libhal/libhal-util
+      dir: v5
+    secrets: inherit
 
-  # libhal-actuator:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-actuator
-  #     repo: libhal/libhal-actuator
-  #   secrets: inherit
+  libhal-actuator:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-actuator
+      repo: libhal/libhal-actuator
+    secrets: inherit
 
-  # libhal-sensor:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-sensor
-  #     repo: libhal/libhal-sensor
-  #   secrets: inherit
+  libhal-sensor:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-sensor
+      repo: libhal/libhal-sensor
+    secrets: inherit
 
-  # libhal-expander:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-expander
-  #     repo: libhal/libhal-expander
-  #   secrets: inherit
+  libhal-expander:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-expander
+      repo: libhal/libhal-expander
+    secrets: inherit
 
-  # libhal-micromod-lint:
-  #   uses: ./.github/workflows/lint.yml
-  #   with:
-  #     library: libhal-micromod
-  #     source_dir: src
-  #     dir: .
-  #     repo: libhal/libhal-micromod
-  #   secrets: inherit
+  libhal-micromod-lint:
+    uses: ./.github/workflows/lint.yml
+    with:
+      library: libhal-micromod
+      source_dir: src
+      dir: .
+      repo: libhal/libhal-micromod
+    secrets: inherit
 
-  # libhal-micromod-docs:
-  #   uses: ./.github/workflows/docs.yml
-  #   with:
-  #     library: libhal-micromod
-  #     source_dir: src
-  #     dir: .
-  #     repo: libhal/libhal-micromod
-  #   secrets: inherit
+  libhal-micromod-docs:
+    uses: ./.github/workflows/docs.yml
+    with:
+      library: libhal-micromod
+      source_dir: src
+      dir: .
+      repo: libhal/libhal-micromod
+    secrets: inherit
 
-  # package-strong_ptr:
-  #   uses: ./.github/workflows/package_and_upload_all.yml
-  #   with:
-  #     library: strong_ptr
-  #     repo: libhal/strong_ptr
-  #     modules_support_needed: true
-  #   secrets: inherit
+  package-strong_ptr:
+    uses: ./.github/workflows/package_and_upload_all.yml
+    with:
+      library: strong_ptr
+      repo: libhal/strong_ptr
+      modules_support_needed: true
+    secrets: inherit
 
-  # package-libhal_v4:
-  #   uses: ./.github/workflows/package_and_upload_all.yml
-  #   with:
-  #     library: libhal
-  #     repo: libhal/libhal
-  #     dir: v4
-  #   secrets: inherit
+  package-libhal_v4:
+    uses: ./.github/workflows/package_and_upload_all.yml
+    with:
+      library: libhal
+      repo: libhal/libhal
+      dir: v4
+    secrets: inherit
 
-  # package-libhal-util:
-  #   uses: ./.github/workflows/package_and_upload_all.yml
-  #   with:
-  #     library: libhal-util
-  #     repo: libhal/libhal-util
-  #     dir: v5
-  #   secrets: inherit
+  package-libhal-util:
+    uses: ./.github/workflows/package_and_upload_all.yml
+    with:
+      library: libhal-util
+      repo: libhal/libhal-util
+      dir: v5
+    secrets: inherit
 
   # TODO(#95): Enable Windows
   # TODO(libhal/async_context#17): Add async-context
@@ -117,44 +117,44 @@ jobs:
       platform_profile: hal/mcu/lpc4078
     secrets: inherit
 
-  # libhal-actuator-demos-lpc4078:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-actuator
-  #     dir: demos
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4078
-  #   secrets: inherit
+  libhal-actuator-demos-lpc4078:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4078
+    secrets: inherit
 
-  # libhal-actuator-demos-lpc4074:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-actuator
-  #     dir: demos
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4074
-  #   secrets: inherit
+  libhal-actuator-demos-lpc4074:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4074
+    secrets: inherit
 
-  # libhal-starter-app-lpc4078:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-starter
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4078
-  #   secrets: inherit
+  libhal-starter-app-lpc4078:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-starter
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4078
+    secrets: inherit
 
-  # libhal-starter-app-stm32f103c8:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-starter
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/stm32f103c8
-  #   secrets: inherit
+  libhal-starter-app-stm32f103c8:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-starter
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/stm32f103c8
+    secrets: inherit
 
-  # libhal-starter-app-mod-stmt32f1-v4:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-starter
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/bsp/mod-stm32f1-v4
-  #   secrets: inherit
+  libhal-starter-app-mod-stmt32f1-v4:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-starter
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/bsp/mod-stm32f1-v4
+    secrets: inherit

--- a/scripts/baremetal_package.sh
+++ b/scripts/baremetal_package.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# # Use defaults
+# ./baremetal_package.sh
+#
+# # Specify custom values
+# ./baremetal_package.sh --dir ./myproject --version 1.2.3 --compiler-profile hal/tc/gcc --arch-list cortex-m0,cortex-m3,cortex-m4
+#
+# # Just change architecture list
+# ./baremetal_package.sh --arch-list cortex-m0,cortex-m1,cortex-m3
+
+# Default values
+DIR="."
+VERSION="latest"
+COMPILER_PROFILE="hal/tc/llvm"
+ARCH_LIST=("cortex-m3")
+CONAN_VERSION=2.23.0
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --dir)
+      DIR="$2"
+      shift 2
+      ;;
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --compiler-profile)
+      COMPILER_PROFILE="$2"
+      shift 2
+      ;;
+    --conan-version)
+      CONAN_VERSION="$2"
+      shift 2
+      ;;
+    --arch-list)
+      IFS=',' read -ra ARCH_LIST <<< "$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--dir DIR] [--version VERSION] [--compiler-profile PROFILE] [--conan-version VERSION] [--arch-list ARCH1,ARCH2,...]"
+      exit 1
+      ;;
+  esac
+done
+
+# Setup conan & libhal
+pipx install conan>=$CONAN_VERSION
+conan config install https://github.com/libhal/conan-config2.git
+conan hal setup
+
+# Loop over architectures and build types
+for ARCH in "${ARCH_LIST[@]}"; do
+  echo "Building for architecture: $ARCH"
+
+  conan create $DIR -s:h build_type=Debug -s:h os=baremetal -s:h arch=$ARCH --version $VERSION -pr:h $COMPILER_PROFILE --build=missing
+
+  conan create $DIR -s:h build_type=MinSizeRel -s:h os=baremetal -s:h arch=$ARCH --version $VERSION -pr:h $COMPILER_PROFILE --build=missing
+
+  conan create $DIR -s:h build_type=Release -s:h os=baremetal -s:h arch=$ARCH --version $VERSION -pr:h $COMPILER_PROFILE --build=missing
+done


### PR DESCRIPTION
Upgrade default Conan version from 2.16.1 to 2.23.0 across workflows
and streamline the setup process by replacing manual remote/profile
configuration with the new `conan hal setup` command.

Consolidate individual Cortex-M architecture jobs into two unified
jobs (LLVM and GCC) using a new baremetal_package.sh script that
builds all architectures sequentially. This reduces workflow
complexity from 14+ separate jobs to 2 consolidated jobs while
maintaining support for all Cortex-M variants (M0, M0+, M1, M3, M4,
M4F, M7F, M7D, M23, M33, M33F, M35PF, M55, M85).

Add modules_support_needed flag to control GCC build execution,
since GCC doesn't currently support C++ modules.

Update compiler profile references from versioned hal/tc/arm-gcc-12.3
to unversioned hal/tc/arm-gcc for better maintainability.