### PR TITLE
:wrench: Add carve out for coroutine support

### DIFF
--- a/.github/workflows/package_and_upload_all.yml
+++ b/.github/workflows/package_and_upload_all.yml
@@ -40,6 +40,9 @@ on:
       modules_support_needed:
         type: boolean
         default: False
+      coroutine_support_needed:
+        type: boolean
+        default: False
       ci_ref:
         type: string
         default: "5.x.y"
@@ -144,6 +147,18 @@ jobs:
 
       - name: 📦 Build packages for all Cortex-M architectures
         working-directory: target-repo
+        if: ${{ inputs.coroutine_support_needed == true }}
+        run: |
+          bash ../ci-repo/scripts/baremetal_package.sh \
+            --dir ${{ inputs.dir }} \
+            --version ${{ inputs.version }} \
+            --compiler-profile hal/tc/llvm \
+            --conan-version ${{ inputs.conan_version }} \
+            --arch-list cortex-m3,cortex-m4,cortex-m4f,cortex-m7f,cortex-m7d,cortex-m23,cortex-m33,cortex-m33f,cortex-m35pf,cortex-m55,cortex-m85
+
+      - name: 📦 Build packages for all Cortex-M architectures
+        working-directory: target-repo
+        if: ${{ inputs.coroutine_support_needed == false }}
         run: |
           bash ../ci-repo/scripts/baremetal_package.sh \
             --dir ${{ inputs.dir }} \


### PR DESCRIPTION
For some reason LLVM 20 cannot build coroutines for cortex-m0, m0plus, and m1. There is a tail call optimization that causes the linker to crash. This simply removes those architectures when coroutines are needed.