### PR TITLE
:sparkles: Add extra_conan_arguments support to package workflows

### DIFF
--- a/.github/workflows/package_and_upload.yml
+++ b/.github/workflows/package_and_upload.yml
@@ -50,6 +50,10 @@ on:
       remote_url: # Path to conan package repo
         type: string
         default: ""
+      extra_conan_arguments:
+        type: string
+        default: ""
+        description: "Extra arguments to pass to conan create commands"
 
     secrets:
       conan_remote_user:
@@ -99,13 +103,13 @@ jobs:
         run: conan config install https://github.com/libhal/conan-config2.git --args="-b ${{ inputs.config2_version }}"
 
       - name: 📦 Create `Debug` package for ${{ inputs.profile }}
-        run: conan create ${{ inputs.dir }} -s:h build_type=Debug -s:h os=${{ inputs.os }} -s:h arch=${{ inputs.arch }} --version=${{ inputs.version }} -pr:h ${{ inputs.compiler_profile }} --build=missing
+        run: conan create ${{ inputs.dir }} -s:h build_type=Debug -s:h os=${{ inputs.os }} -s:h arch=${{ inputs.arch }} --version=${{ inputs.version }} -pr:h ${{ inputs.compiler_profile }} --build=missing ${{ inputs.extra_conan_arguments }}
 
       - name: 📦 Create `MinSizeRel` package for ${{ inputs.profile }}
-        run: conan create ${{ inputs.dir }} -s:h build_type=MinSizeRel -s:h os=${{ inputs.os }} -s:h arch=${{ inputs.arch }} --version=${{ inputs.version }} -pr:h ${{ inputs.compiler_profile }} --build=missing
+        run: conan create ${{ inputs.dir }} -s:h build_type=MinSizeRel -s:h os=${{ inputs.os }} -s:h arch=${{ inputs.arch }} --version=${{ inputs.version }} -pr:h ${{ inputs.compiler_profile }} --build=missing ${{ inputs.extra_conan_arguments }}
 
       - name: 📦 Create `Release` package for ${{ inputs.profile }}
-        run: conan create ${{ inputs.dir }} -s:h build_type=Release  -s:h os=${{ inputs.os }} -s:h arch=${{ inputs.arch }} --version=${{ inputs.version }} -pr:h ${{ inputs.compiler_profile }} --build=missing
+        run: conan create ${{ inputs.dir }} -s:h build_type=Release  -s:h os=${{ inputs.os }} -s:h arch=${{ inputs.arch }} --version=${{ inputs.version }} -pr:h ${{ inputs.compiler_profile }} --build=missing ${{ inputs.extra_conan_arguments }}
 
       - name: 📡 Sign into Conan Package Repository
         if: ${{ inputs.version != 'latest' && inputs.remote_url != '' && env.CONAN_REMOTE_USER != '' && env.CONAN_REMOTE_PASSWORD != '' }}

--- a/.github/workflows/package_and_upload_all.yml
+++ b/.github/workflows/package_and_upload_all.yml
@@ -47,6 +47,10 @@ on:
         type: string
         default: "5.x.y"
         description: "Git ref (branch, tag, or SHA) of libhal/ci to use for scripts"
+      extra_conan_arguments:
+        type: string
+        default: ""
+        description: "Extra arguments to pass to conan create commands"
 
     secrets:
       conan_remote_password:
@@ -70,6 +74,7 @@ jobs:
       version: ${{ inputs.version }}
       dir: ${{ inputs.dir }}
       remote_url: ${{ inputs.remote_url }}
+      extra_conan_arguments: ${{ inputs.extra_conan_arguments }}
     secrets:
       conan_remote_user: ${{ secrets.conan_remote_user }}
       conan_remote_password: ${{ secrets.conan_remote_password }}
@@ -89,6 +94,7 @@ jobs:
       version: ${{ inputs.version }}
       dir: ${{ inputs.dir }}
       remote_url: ${{ inputs.remote_url }}
+      extra_conan_arguments: ${{ inputs.extra_conan_arguments }}
     secrets:
       conan_remote_user: ${{ secrets.conan_remote_user }}
       conan_remote_password: ${{ secrets.conan_remote_password }}
@@ -108,6 +114,7 @@ jobs:
       version: ${{ inputs.version }}
       dir: ${{ inputs.dir }}
       remote_url: ${{ inputs.remote_url }}
+      extra_conan_arguments: ${{ inputs.extra_conan_arguments }}
     secrets:
       conan_remote_user: ${{ secrets.conan_remote_user }}
       conan_remote_password: ${{ secrets.conan_remote_password }}
@@ -154,7 +161,8 @@ jobs:
             --version ${{ inputs.version }} \
             --compiler-profile hal/tc/llvm \
             --conan-version ${{ inputs.conan_version }} \
-            --arch-list cortex-m3,cortex-m4,cortex-m4f,cortex-m7f,cortex-m7d,cortex-m23,cortex-m33,cortex-m33f,cortex-m35pf,cortex-m55,cortex-m85
+            --arch-list cortex-m3,cortex-m4,cortex-m4f,cortex-m7f,cortex-m7d,cortex-m23,cortex-m33,cortex-m33f,cortex-m35pf,cortex-m55,cortex-m85 \
+            --extra-conan-args "${{ inputs.extra_conan_arguments }}"
 
       - name: 📦 Build packages for all Cortex-M architectures
         working-directory: target-repo
@@ -165,7 +173,8 @@ jobs:
             --version ${{ inputs.version }} \
             --compiler-profile hal/tc/llvm \
             --conan-version ${{ inputs.conan_version }} \
-            --arch-list cortex-m0,cortex-m0plus,cortex-m1,cortex-m3,cortex-m4,cortex-m4f,cortex-m7f,cortex-m7d,cortex-m23,cortex-m33,cortex-m33f,cortex-m35pf,cortex-m55,cortex-m85
+            --arch-list cortex-m0,cortex-m0plus,cortex-m1,cortex-m3,cortex-m4,cortex-m4f,cortex-m7f,cortex-m7d,cortex-m23,cortex-m33,cortex-m33f,cortex-m35pf,cortex-m55,cortex-m85 \
+            --extra-conan-args "${{ inputs.extra_conan_arguments }}"
 
       - name: 📡 Add conan user remote-package-repo
         if: ${{ inputs.remote_url != '' }}
@@ -221,7 +230,8 @@ jobs:
             --version ${{ inputs.version }} \
             --compiler-profile hal/tc/arm-gcc \
             --conan-version ${{ inputs.conan_version }} \
-            --arch-list cortex-m0,cortex-m0plus,cortex-m1,cortex-m3,cortex-m4,cortex-m4f,cortex-m7f,cortex-m7d,cortex-m23,cortex-m33,cortex-m33f,cortex-m35pf,cortex-m55,cortex-m85
+            --arch-list cortex-m0,cortex-m0plus,cortex-m1,cortex-m3,cortex-m4,cortex-m4f,cortex-m7f,cortex-m7d,cortex-m23,cortex-m33,cortex-m33f,cortex-m35pf,cortex-m55,cortex-m85 \
+            --extra-conan-args "${{ inputs.extra_conan_arguments }}"
 
       - name: 📡 Add conan user remote-package-repo
         if: ${{ inputs.remote_url != '' }}

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -28,60 +28,60 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # library_check_libhal_v4:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal
-  #     repo: libhal/libhal
-  #     dir: v4
-  #   secrets: inherit
+  library_check_libhal_v4:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal
+      repo: libhal/libhal
+      dir: v4
+    secrets: inherit
 
-  # library_check_libhal-util:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-util
-  #     repo: libhal/libhal-util
-  #     dir: v5
-  #   secrets: inherit
+  library_check_libhal-util:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-util
+      repo: libhal/libhal-util
+      dir: v5
+    secrets: inherit
 
-  # libhal-actuator:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-actuator
-  #     repo: libhal/libhal-actuator
-  #   secrets: inherit
+  libhal-actuator:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-actuator
+      repo: libhal/libhal-actuator
+    secrets: inherit
 
-  # libhal-sensor:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-sensor
-  #     repo: libhal/libhal-sensor
-  #   secrets: inherit
+  libhal-sensor:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-sensor
+      repo: libhal/libhal-sensor
+    secrets: inherit
 
-  # libhal-expander:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-expander
-  #     repo: libhal/libhal-expander
-  #   secrets: inherit
+  libhal-expander:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-expander
+      repo: libhal/libhal-expander
+    secrets: inherit
 
-  # libhal-micromod-lint:
-  #   uses: ./.github/workflows/lint.yml
-  #   with:
-  #     library: libhal-micromod
-  #     source_dir: src
-  #     dir: .
-  #     repo: libhal/libhal-micromod
-  #   secrets: inherit
+  libhal-micromod-lint:
+    uses: ./.github/workflows/lint.yml
+    with:
+      library: libhal-micromod
+      source_dir: src
+      dir: .
+      repo: libhal/libhal-micromod
+    secrets: inherit
 
-  # libhal-micromod-docs:
-  #   uses: ./.github/workflows/docs.yml
-  #   with:
-  #     library: libhal-micromod
-  #     source_dir: src
-  #     dir: .
-  #     repo: libhal/libhal-micromod
-  #   secrets: inherit
+  libhal-micromod-docs:
+    uses: ./.github/workflows/docs.yml
+    with:
+      library: libhal-micromod
+      source_dir: src
+      dir: .
+      repo: libhal/libhal-micromod
+    secrets: inherit
 
   package-strong_ptr:
     uses: ./.github/workflows/package_and_upload_all.yml
@@ -115,53 +115,53 @@ jobs:
   # TODO(libhal/libhal#178): Add libhal v5
   # TODO(libhal/libhal-util#87): Add libhal-util v6
 
-  # libhal-arm-mcu-lpc4078-demos:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-arm-mcu
-  #     dir: demos
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4078
-  #   secrets: inherit
+  libhal-arm-mcu-lpc4078-demos:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-arm-mcu
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4078
+    secrets: inherit
 
-  # libhal-actuator-demos-lpc4078:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-actuator
-  #     dir: demos
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4078
-  #   secrets: inherit
+  libhal-actuator-demos-lpc4078:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4078
+    secrets: inherit
 
-  # libhal-actuator-demos-lpc4074:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-actuator
-  #     dir: demos
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4074
-  #   secrets: inherit
+  libhal-actuator-demos-lpc4074:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4074
+    secrets: inherit
 
-  # libhal-starter-app-lpc4078:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-starter
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4078
-  #   secrets: inherit
+  libhal-starter-app-lpc4078:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-starter
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4078
+    secrets: inherit
 
-  # libhal-starter-app-stm32f103c8:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-starter
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/stm32f103c8
-  #   secrets: inherit
+  libhal-starter-app-stm32f103c8:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-starter
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/stm32f103c8
+    secrets: inherit
 
-  # libhal-starter-app-mod-stmt32f1-v4:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-starter
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/bsp/mod-stm32f1-v4
-  #   secrets: inherit
+  libhal-starter-app-mod-stmt32f1-v4:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-starter
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/bsp/mod-stm32f1-v4
+    secrets: inherit

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -23,61 +23,65 @@ on:
     - cron: "0 12 * * 0"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  library_check_libhal_v4:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal
-      repo: libhal/libhal
-      dir: v4
-    secrets: inherit
+  # library_check_libhal_v4:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal
+  #     repo: libhal/libhal
+  #     dir: v4
+  #   secrets: inherit
 
-  library_check_libhal-util:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-util
-      repo: libhal/libhal-util
-      dir: v5
-    secrets: inherit
+  # library_check_libhal-util:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-util
+  #     repo: libhal/libhal-util
+  #     dir: v5
+  #   secrets: inherit
 
-  libhal-actuator:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-actuator
-      repo: libhal/libhal-actuator
-    secrets: inherit
+  # libhal-actuator:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-actuator
+  #     repo: libhal/libhal-actuator
+  #   secrets: inherit
 
-  libhal-sensor:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-sensor
-      repo: libhal/libhal-sensor
-    secrets: inherit
+  # libhal-sensor:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-sensor
+  #     repo: libhal/libhal-sensor
+  #   secrets: inherit
 
-  libhal-expander:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-expander
-      repo: libhal/libhal-expander
-    secrets: inherit
+  # libhal-expander:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-expander
+  #     repo: libhal/libhal-expander
+  #   secrets: inherit
 
-  libhal-micromod-lint:
-    uses: ./.github/workflows/lint.yml
-    with:
-      library: libhal-micromod
-      source_dir: src
-      dir: .
-      repo: libhal/libhal-micromod
-    secrets: inherit
+  # libhal-micromod-lint:
+  #   uses: ./.github/workflows/lint.yml
+  #   with:
+  #     library: libhal-micromod
+  #     source_dir: src
+  #     dir: .
+  #     repo: libhal/libhal-micromod
+  #   secrets: inherit
 
-  libhal-micromod-docs:
-    uses: ./.github/workflows/docs.yml
-    with:
-      library: libhal-micromod
-      source_dir: src
-      dir: .
-      repo: libhal/libhal-micromod
-    secrets: inherit
+  # libhal-micromod-docs:
+  #   uses: ./.github/workflows/docs.yml
+  #   with:
+  #     library: libhal-micromod
+  #     source_dir: src
+  #     dir: .
+  #     repo: libhal/libhal-micromod
+  #   secrets: inherit
 
   package-strong_ptr:
     uses: ./.github/workflows/package_and_upload_all.yml
@@ -85,6 +89,7 @@ jobs:
       library: strong_ptr
       repo: libhal/strong_ptr
       modules_support_needed: true
+      ci_ref: ${{ github.head_ref || github.ref_name }}
     secrets: inherit
 
   package-libhal_v4:
@@ -93,6 +98,7 @@ jobs:
       library: libhal
       repo: libhal/libhal
       dir: v4
+      ci_ref: ${{ github.head_ref || github.ref_name }}
     secrets: inherit
 
   package-libhal-util:
@@ -101,6 +107,7 @@ jobs:
       library: libhal-util
       repo: libhal/libhal-util
       dir: v5
+      ci_ref: ${{ github.head_ref || github.ref_name }}
     secrets: inherit
 
   # TODO(#95): Enable Windows
@@ -108,53 +115,53 @@ jobs:
   # TODO(libhal/libhal#178): Add libhal v5
   # TODO(libhal/libhal-util#87): Add libhal-util v6
 
-  libhal-arm-mcu-lpc4078-demos:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-arm-mcu
-      dir: demos
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/mcu/lpc4078
-    secrets: inherit
+  # libhal-arm-mcu-lpc4078-demos:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-arm-mcu
+  #     dir: demos
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4078
+  #   secrets: inherit
 
-  libhal-actuator-demos-lpc4078:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-actuator
-      dir: demos
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/mcu/lpc4078
-    secrets: inherit
+  # libhal-actuator-demos-lpc4078:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-actuator
+  #     dir: demos
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4078
+  #   secrets: inherit
 
-  libhal-actuator-demos-lpc4074:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-actuator
-      dir: demos
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/mcu/lpc4074
-    secrets: inherit
+  # libhal-actuator-demos-lpc4074:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-actuator
+  #     dir: demos
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4074
+  #   secrets: inherit
 
-  libhal-starter-app-lpc4078:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-starter
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/mcu/lpc4078
-    secrets: inherit
+  # libhal-starter-app-lpc4078:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-starter
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4078
+  #   secrets: inherit
 
-  libhal-starter-app-stm32f103c8:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-starter
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/mcu/stm32f103c8
-    secrets: inherit
+  # libhal-starter-app-stm32f103c8:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-starter
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/stm32f103c8
+  #   secrets: inherit
 
-  libhal-starter-app-mod-stmt32f1-v4:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-starter
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/bsp/mod-stm32f1-v4
-    secrets: inherit
+  # libhal-starter-app-mod-stmt32f1-v4:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-starter
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/bsp/mod-stm32f1-v4
+  #   secrets: inherit

--- a/scripts/baremetal_package.sh
+++ b/scripts/baremetal_package.sh
@@ -18,6 +18,7 @@ VERSION="latest"
 COMPILER_PROFILE="hal/tc/llvm"
 ARCH_LIST=("cortex-m3")
 CONAN_VERSION=2.23.0
+EXTRA_CONAN_ARGS=""
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -42,9 +43,13 @@ while [[ $# -gt 0 ]]; do
       IFS=',' read -ra ARCH_LIST <<< "$2"
       shift 2
       ;;
+    --extra-conan-args)
+      EXTRA_CONAN_ARGS="$2"
+      shift 2
+      ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $0 [--dir DIR] [--version VERSION] [--compiler-profile PROFILE] [--conan-version VERSION] [--arch-list ARCH1,ARCH2,...]"
+      echo "Usage: $0 [--dir DIR] [--version VERSION] [--compiler-profile PROFILE] [--conan-version VERSION] [--arch-list ARCH1,ARCH2,...] [--extra-conan-args ARGS]"
       exit 1
       ;;
   esac
@@ -59,9 +64,9 @@ conan hal setup
 for ARCH in "${ARCH_LIST[@]}"; do
   echo "Building for architecture: $ARCH"
 
-  conan create $DIR -s:h build_type=Debug -s:h os=baremetal -s:h arch=$ARCH --version $VERSION -pr:h $COMPILER_PROFILE --build=missing
+  conan create $DIR -s:h build_type=Debug -s:h os=baremetal -s:h arch=$ARCH --version $VERSION -pr:h $COMPILER_PROFILE --build=missing $EXTRA_CONAN_ARGS
 
-  conan create $DIR -s:h build_type=MinSizeRel -s:h os=baremetal -s:h arch=$ARCH --version $VERSION -pr:h $COMPILER_PROFILE --build=missing
+  conan create $DIR -s:h build_type=MinSizeRel -s:h os=baremetal -s:h arch=$ARCH --version $VERSION -pr:h $COMPILER_PROFILE --build=missing $EXTRA_CONAN_ARGS
 
-  conan create $DIR -s:h build_type=Release -s:h os=baremetal -s:h arch=$ARCH --version $VERSION -pr:h $COMPILER_PROFILE --build=missing
+  conan create $DIR -s:h build_type=Release -s:h os=baremetal -s:h arch=$ARCH --version $VERSION -pr:h $COMPILER_PROFILE --build=missing $EXTRA_CONAN_ARGS
 done


### PR DESCRIPTION
Add new `extra_conan_arguments` input parameter to pass additional arguments to conan create commands. This enables customization of package builds with options like C++ modules, freestanding mode, and other conan options.

- Add extra_conan_arguments input to package_and_upload_all.yml
- Add extra_conan_arguments input to package_and_upload.yml
- Add --extra-conan-args parameter to baremetal_package.sh
- Pass arguments through to all conan create invocations