### PR TITLE
:sparkles: Add latest library builds to app_builder2.yml

### DIFF
--- a/.github/workflows/app_builder2.yml
+++ b/.github/workflows/app_builder2.yml
@@ -38,6 +38,10 @@ on:
       dir: # Directory where the conan package exists
         type: string
         default: "."
+      library_dir:
+        type: string
+        default: ""
+        description: "Specify the library directory to create a library package using the platform and compiler profiles. A version will not be supplied. The package should default to either 'latest' OR something that the application can understand."
 
 jobs:
   build:
@@ -64,6 +68,10 @@ jobs:
 
       - name: Setup libhal
         run: conan hal setup
+
+      - name: 📦 Create Package "${{ inputs.library_dir }}" @ version=latest
+        if: ${{ inputs.library_dir != '' }}
+        run: conan create ${{ inputs.library_dir }} -pr ${{ inputs.compiler_profile }} -pr ${{ inputs.platform_profile }} --version=latest
 
       - name: 🏗️ Build Application for ${{ inputs.profile }}
         run: conan build ${{ inputs.dir }} -pr ${{ inputs.compiler_profile }} -pr ${{ inputs.platform_profile }}

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -28,140 +28,149 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  library_check_libhal_v4:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal
-      repo: libhal/libhal
-      dir: v4
-    secrets: inherit
+  # library_check_libhal_v4:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal
+  #     repo: libhal/libhal
+  #     dir: v4
+  #   secrets: inherit
 
-  library_check_libhal-util:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-util
-      repo: libhal/libhal-util
-      dir: v5
-    secrets: inherit
+  # library_check_libhal-util:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-util
+  #     repo: libhal/libhal-util
+  #     dir: v5
+  #   secrets: inherit
 
-  libhal-actuator:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-actuator
-      repo: libhal/libhal-actuator
-    secrets: inherit
+  # libhal-actuator:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-actuator
+  #     repo: libhal/libhal-actuator
+  #   secrets: inherit
 
-  libhal-sensor:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-sensor
-      repo: libhal/libhal-sensor
-    secrets: inherit
+  # libhal-sensor:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-sensor
+  #     repo: libhal/libhal-sensor
+  #   secrets: inherit
 
-  libhal-expander:
-    uses: ./.github/workflows/library_check.yml
-    with:
-      library: libhal-expander
-      repo: libhal/libhal-expander
-    secrets: inherit
+  # libhal-expander:
+  #   uses: ./.github/workflows/library_check.yml
+  #   with:
+  #     library: libhal-expander
+  #     repo: libhal/libhal-expander
+  #   secrets: inherit
 
-  libhal-micromod-lint:
-    uses: ./.github/workflows/lint.yml
-    with:
-      library: libhal-micromod
-      source_dir: src
-      dir: .
-      repo: libhal/libhal-micromod
-    secrets: inherit
+  # libhal-micromod-lint:
+  #   uses: ./.github/workflows/lint.yml
+  #   with:
+  #     library: libhal-micromod
+  #     source_dir: src
+  #     dir: .
+  #     repo: libhal/libhal-micromod
+  #   secrets: inherit
 
-  libhal-micromod-docs:
-    uses: ./.github/workflows/docs.yml
-    with:
-      library: libhal-micromod
-      source_dir: src
-      dir: .
-      repo: libhal/libhal-micromod
-    secrets: inherit
+  # libhal-micromod-docs:
+  #   uses: ./.github/workflows/docs.yml
+  #   with:
+  #     library: libhal-micromod
+  #     source_dir: src
+  #     dir: .
+  #     repo: libhal/libhal-micromod
+  #   secrets: inherit
 
-  package-strong_ptr:
-    uses: ./.github/workflows/package_and_upload_all.yml
-    with:
-      library: strong_ptr
-      repo: libhal/strong_ptr
-      modules_support_needed: true
-      ci_ref: ${{ github.head_ref || github.ref_name }}
-    secrets: inherit
+  # package-strong_ptr:
+  #   uses: ./.github/workflows/package_and_upload_all.yml
+  #   with:
+  #     library: strong_ptr
+  #     repo: libhal/strong_ptr
+  #     modules_support_needed: true
+  #     ci_ref: ${{ github.head_ref || github.ref_name }}
+  #   secrets: inherit
 
-  package-libhal_v4:
-    uses: ./.github/workflows/package_and_upload_all.yml
-    with:
-      library: libhal
-      repo: libhal/libhal
-      dir: v4
-      ci_ref: ${{ github.head_ref || github.ref_name }}
-    secrets: inherit
+  # package-libhal_v4:
+  #   uses: ./.github/workflows/package_and_upload_all.yml
+  #   with:
+  #     library: libhal
+  #     repo: libhal/libhal
+  #     dir: v4
+  #     ci_ref: ${{ github.head_ref || github.ref_name }}
+  #   secrets: inherit
 
-  package-libhal-util:
-    uses: ./.github/workflows/package_and_upload_all.yml
-    with:
-      library: libhal-util
-      repo: libhal/libhal-util
-      dir: v5
-      ci_ref: ${{ github.head_ref || github.ref_name }}
-    secrets: inherit
+  # package-libhal-util:
+  #   uses: ./.github/workflows/package_and_upload_all.yml
+  #   with:
+  #     library: libhal-util
+  #     repo: libhal/libhal-util
+  #     dir: v5
+  #     ci_ref: ${{ github.head_ref || github.ref_name }}
+  #   secrets: inherit
 
   # TODO(#95): Enable Windows
   # TODO(libhal/async_context#17): Add async-context
   # TODO(libhal/libhal#178): Add libhal v5
   # TODO(libhal/libhal-util#87): Add libhal-util v6
 
-  libhal-arm-mcu-lpc4078-demos:
+  # libhal-arm-mcu-lpc4078-demos:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-arm-mcu
+  #     dir: demos
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4078
+  #   secrets: inherit
+
+  libhal-expander-build-latest:
     uses: ./.github/workflows/app_builder2.yml
     with:
-      repo: libhal/libhal-arm-mcu
+      repo: libhal/libhal-expander
       dir: demos
+      library_dir: .
       compiler_profile: hal/tc/arm-gcc
       platform_profile: hal/mcu/lpc4078
-    secrets: inherit
 
-  libhal-actuator-demos-lpc4078:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-actuator
-      dir: demos
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/mcu/lpc4078
-    secrets: inherit
+  # libhal-actuator-demos-lpc4078:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-actuator
+  #     dir: demos
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4078
+  #   secrets: inherit
 
-  libhal-actuator-demos-lpc4074:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-actuator
-      dir: demos
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/mcu/lpc4074
-    secrets: inherit
+  # libhal-actuator-demos-lpc4074:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-actuator
+  #     dir: demos
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4074
+  #   secrets: inherit
 
-  libhal-starter-app-lpc4078:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-starter
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/mcu/lpc4078
-    secrets: inherit
+  # libhal-starter-app-lpc4078:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-starter
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/lpc4078
+  #   secrets: inherit
 
-  libhal-starter-app-stm32f103c8:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-starter
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/mcu/stm32f103c8
-    secrets: inherit
+  # libhal-starter-app-stm32f103c8:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-starter
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/mcu/stm32f103c8
+  #   secrets: inherit
 
-  libhal-starter-app-mod-stmt32f1-v4:
-    uses: ./.github/workflows/app_builder2.yml
-    with:
-      repo: libhal/libhal-starter
-      compiler_profile: hal/tc/arm-gcc
-      platform_profile: hal/bsp/mod-stm32f1-v4
-    secrets: inherit
+  # libhal-starter-app-mod-stmt32f1-v4:
+  #   uses: ./.github/workflows/app_builder2.yml
+  #   with:
+  #     repo: libhal/libhal-starter
+  #     compiler_profile: hal/tc/arm-gcc
+  #     platform_profile: hal/bsp/mod-stm32f1-v4
+  #   secrets: inherit

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -28,101 +28,101 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # library_check_libhal_v4:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal
-  #     repo: libhal/libhal
-  #     dir: v4
-  #   secrets: inherit
+  library_check_libhal_v4:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal
+      repo: libhal/libhal
+      dir: v4
+    secrets: inherit
 
-  # library_check_libhal-util:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-util
-  #     repo: libhal/libhal-util
-  #     dir: v5
-  #   secrets: inherit
+  library_check_libhal-util:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-util
+      repo: libhal/libhal-util
+      dir: v5
+    secrets: inherit
 
-  # libhal-actuator:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-actuator
-  #     repo: libhal/libhal-actuator
-  #   secrets: inherit
+  libhal-actuator:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-actuator
+      repo: libhal/libhal-actuator
+    secrets: inherit
 
-  # libhal-sensor:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-sensor
-  #     repo: libhal/libhal-sensor
-  #   secrets: inherit
+  libhal-sensor:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-sensor
+      repo: libhal/libhal-sensor
+    secrets: inherit
 
-  # libhal-expander:
-  #   uses: ./.github/workflows/library_check.yml
-  #   with:
-  #     library: libhal-expander
-  #     repo: libhal/libhal-expander
-  #   secrets: inherit
+  libhal-expander:
+    uses: ./.github/workflows/library_check.yml
+    with:
+      library: libhal-expander
+      repo: libhal/libhal-expander
+    secrets: inherit
 
-  # libhal-micromod-lint:
-  #   uses: ./.github/workflows/lint.yml
-  #   with:
-  #     library: libhal-micromod
-  #     source_dir: src
-  #     dir: .
-  #     repo: libhal/libhal-micromod
-  #   secrets: inherit
+  libhal-micromod-lint:
+    uses: ./.github/workflows/lint.yml
+    with:
+      library: libhal-micromod
+      source_dir: src
+      dir: .
+      repo: libhal/libhal-micromod
+    secrets: inherit
 
-  # libhal-micromod-docs:
-  #   uses: ./.github/workflows/docs.yml
-  #   with:
-  #     library: libhal-micromod
-  #     source_dir: src
-  #     dir: .
-  #     repo: libhal/libhal-micromod
-  #   secrets: inherit
+  libhal-micromod-docs:
+    uses: ./.github/workflows/docs.yml
+    with:
+      library: libhal-micromod
+      source_dir: src
+      dir: .
+      repo: libhal/libhal-micromod
+    secrets: inherit
 
-  # package-strong_ptr:
-  #   uses: ./.github/workflows/package_and_upload_all.yml
-  #   with:
-  #     library: strong_ptr
-  #     repo: libhal/strong_ptr
-  #     modules_support_needed: true
-  #     ci_ref: ${{ github.head_ref || github.ref_name }}
-  #   secrets: inherit
+  package-strong_ptr:
+    uses: ./.github/workflows/package_and_upload_all.yml
+    with:
+      library: strong_ptr
+      repo: libhal/strong_ptr
+      modules_support_needed: true
+      ci_ref: ${{ github.head_ref || github.ref_name }}
+    secrets: inherit
 
-  # package-libhal_v4:
-  #   uses: ./.github/workflows/package_and_upload_all.yml
-  #   with:
-  #     library: libhal
-  #     repo: libhal/libhal
-  #     dir: v4
-  #     ci_ref: ${{ github.head_ref || github.ref_name }}
-  #   secrets: inherit
+  package-libhal_v4:
+    uses: ./.github/workflows/package_and_upload_all.yml
+    with:
+      library: libhal
+      repo: libhal/libhal
+      dir: v4
+      ci_ref: ${{ github.head_ref || github.ref_name }}
+    secrets: inherit
 
-  # package-libhal-util:
-  #   uses: ./.github/workflows/package_and_upload_all.yml
-  #   with:
-  #     library: libhal-util
-  #     repo: libhal/libhal-util
-  #     dir: v5
-  #     ci_ref: ${{ github.head_ref || github.ref_name }}
-  #   secrets: inherit
+  package-libhal-util:
+    uses: ./.github/workflows/package_and_upload_all.yml
+    with:
+      library: libhal-util
+      repo: libhal/libhal-util
+      dir: v5
+      ci_ref: ${{ github.head_ref || github.ref_name }}
+    secrets: inherit
 
   # TODO(#95): Enable Windows
   # TODO(libhal/async_context#17): Add async-context
   # TODO(libhal/libhal#178): Add libhal v5
   # TODO(libhal/libhal-util#87): Add libhal-util v6
 
-  # libhal-arm-mcu-lpc4078-demos:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-arm-mcu
-  #     dir: demos
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4078
-  #   secrets: inherit
+  libhal-arm-mcu-lpc4078-demos:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-arm-mcu
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4078
+    secrets: inherit
 
   libhal-expander-build-latest:
     uses: ./.github/workflows/app_builder2.yml
@@ -133,44 +133,44 @@ jobs:
       compiler_profile: hal/tc/arm-gcc
       platform_profile: hal/mcu/lpc4078
 
-  # libhal-actuator-demos-lpc4078:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-actuator
-  #     dir: demos
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4078
-  #   secrets: inherit
+  libhal-actuator-demos-lpc4078:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4078
+    secrets: inherit
 
-  # libhal-actuator-demos-lpc4074:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-actuator
-  #     dir: demos
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4074
-  #   secrets: inherit
+  libhal-actuator-demos-lpc4074:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-actuator
+      dir: demos
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4074
+    secrets: inherit
 
-  # libhal-starter-app-lpc4078:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-starter
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/lpc4078
-  #   secrets: inherit
+  libhal-starter-app-lpc4078:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-starter
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/lpc4078
+    secrets: inherit
 
-  # libhal-starter-app-stm32f103c8:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-starter
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/mcu/stm32f103c8
-  #   secrets: inherit
+  libhal-starter-app-stm32f103c8:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-starter
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/mcu/stm32f103c8
+    secrets: inherit
 
-  # libhal-starter-app-mod-stmt32f1-v4:
-  #   uses: ./.github/workflows/app_builder2.yml
-  #   with:
-  #     repo: libhal/libhal-starter
-  #     compiler_profile: hal/tc/arm-gcc
-  #     platform_profile: hal/bsp/mod-stm32f1-v4
-  #   secrets: inherit
+  libhal-starter-app-mod-stmt32f1-v4:
+    uses: ./.github/workflows/app_builder2.yml
+    with:
+      repo: libhal/libhal-starter
+      compiler_profile: hal/tc/arm-gcc
+      platform_profile: hal/bsp/mod-stm32f1-v4
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ Builds applications/demos for embedded platforms using the new conan-config2 sys
 - `platform_profile` (string, **required**): Platform profile path (e.g., "hal/mcu/lpc4078")
 - `config2_version` (string): Branch/tag of conan-config2 to use. Default: "main"
 - `dir` (string): Directory containing the application. Default: "."
+- `library_dir` (string): Directory containing the directory of a library
+  needed for the application to build. The library's version will be hard set
+  to `latest`. If this input is left empty, then the library build step is
+  skipped. Default: "".
 
 **Usage:**
 


### PR DESCRIPTION
This is to assist with demo applications where a library with version `latest` must be available for the demos to build.