### PR TITLE
:zap: API branch names are just repo names

### DIFF
--- a/.github/scripts/api_deploy.py
+++ b/.github/scripts/api_deploy.py
@@ -192,7 +192,7 @@ def create_pr_or_update_branch_on_api_repo(
 
     # Generate a branch name if not provided
     if not branch_name:
-        branch_name = f"{repo_name}-{version}"
+        branch_name = f"{repo_name}"
 
     # Create PR using GitHub API (requires GitHub token)
     github_token = os.environ.get('GITHUB_TOKEN')

--- a/.github/workflows/api_docs_gen.yml
+++ b/.github/workflows/api_docs_gen.yml
@@ -20,12 +20,28 @@ on:
       dir:
         type: string
         default: .
+      version:
+        type: string
+        default: ${{ github.ref_name }}
+      repo:
+        type: string
+        default: ${{ github.repository }}
+      repo_name:
+        type: string
+        default: ${{ github.event.repository.name }}
+      dry_run:
+        type: boolean
+        default: false
 
 jobs:
   generate_api_docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.version }}
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -34,8 +50,10 @@ jobs:
       - run: pipx install conan>=2.20.0
       - run: pip install -r ${{ inputs.dir }}/docs/requirements.txt gitpython requests
       - run: conan config install https://github.com/libhal/conan-config2.git
-      - run: conan hal docs --doc_version ${{ github.ref_name }} ${{ inputs.dir }}/docs
+      - run: conan hal docs --doc_version ${{ inputs.version }} ${{ inputs.dir }}/docs
       - run: wget https://raw.githubusercontent.com/libhal/ci/5.x.y/.github/scripts/api_deploy.py
-      - run: python api_deploy.py deploy --version ${{ github.ref_name }} --repo-name ${{ github.event.repository.name }} --docs-dir ${{ inputs.dir }}/docs/build/
+      - name: Deploy to API repo
+        if: ${{ inputs.dry_run == false }}
+        run: python api_deploy.py deploy --version ${{ inputs.version }} --repo-name ${{ inputs.repo_name }} --docs-dir ${{ inputs.dir }}/docs/build/
         env:
           GITHUB_TOKEN: ${{ secrets.API_PUSH_TOKEN }}

--- a/.github/workflows/self_check.yml
+++ b/.github/workflows/self_check.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       library_check: ${{ steps.filter.outputs.library_check }}
+      api_docs: ${{ steps.filter.outputs.api_docs }}
       lint: ${{ steps.filter.outputs.lint }}
       docs: ${{ steps.filter.outputs.docs }}
       package_and_upload_all: ${{ steps.filter.outputs.package_and_upload_all }}
@@ -43,6 +44,8 @@ jobs:
         id: filter
         with:
           filters: |
+            api_docs:
+              - '.github/workflows/api_docs_gen.yml'
             library_check:
               - '.github/workflows/library_check.yml'
             tests:
@@ -56,6 +59,30 @@ jobs:
               - '.github/workflows/package_and_upload.yml'
             app_builder2:
               - '.github/workflows/app_builder2.yml'
+
+  api_strong_ptr:
+    needs: changes
+    if: ${{ needs.changes.outputs.api_docs == 'true' }}
+    uses: ./.github/workflows/api_docs_gen.yml
+    with:
+      repo_name: strong_ptr
+      repo: libhal/strong_ptr
+      dir: .
+      dry_run: true
+      version: main
+    secrets: inherit
+
+  api_libhal_v4:
+    needs: changes
+    if: ${{ needs.changes.outputs.api_docs == 'true' }}
+    uses: ./.github/workflows/api_docs_gen.yml
+    with:
+      repo_name: libhal
+      repo: libhal/libhal
+      dir: v4
+      dry_run: true
+      version: main
+    secrets: inherit
 
   library_check_libhal_v4:
     needs: changes


### PR DESCRIPTION
The version number will no longer be used to create branch names for API docs. This prevents a large number of branches being created. Now PRs for the API repo will stack commits for each version created. If a version, like main, is change multiple times, this will look like a commit updating the previous contents of the `main` version files.

Resolves #116