### PR TITLE
:ambulance: Migrate to macos-15 from latest

### DIFF
--- a/.github/workflows/package_and_upload_all.yml
+++ b/.github/workflows/package_and_upload_all.yml
@@ -101,12 +101,12 @@ jobs:
       conan_remote_user: ${{ secrets.conan_remote_user }}
       conan_remote_password: ${{ secrets.conan_remote_password }}
 
-  mac_os_x_latest_llvm:
+  mac_os_x_15_llvm:
     uses: ./.github/workflows/package_and_upload.yml
     with:
       name: 🐉 LLVM 🍎 Mac ARM64
       # Target specific
-      runner_os: macos-latest
+      runner_os: macos-15
       arch: armv8
       os: Macos
       compiler_profile: hal/tc/llvm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
           - runner_os: ubuntu-24.04
             arch: x86_64
             os: Linux
-          - runner_os: macos-latest
+          - runner_os: macos-15
             arch: armv8
             os: Macos
           # # ==================================================================

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Creates Conan packages for a specific platform/architecture and uploads to a rep
 - `conan_version` (string): Conan version. Default: "2.18.0"
 - `config2_version` (string): conan-config2 branch/tag. Default: "main"
 - `version` (string): Package version. Default: "latest" (no upload)
-- `runner_os` (string, **required**): GitHub runner OS (e.g., "ubuntu-24.04", "macos-latest")
+- `runner_os` (string, **required**): GitHub runner OS (e.g., "ubuntu-24.04", "macos-15")
 - `arch` (string, **required**): Target architecture (e.g., "x86_64", "cortex-m4f")
 - `os` (string, **required**): Target OS (e.g., "Linux", "baremetal")
 - `compiler_profile` (string, **required**): Compiler profile path


### PR DESCRIPTION
Since latest is a moving target, I've moved the system to macos-15. Currently, LLVM 20 binaries built with ASAN will halt on macos-26.

The binaries generated by macos-15 should work on any other ARM macos version.